### PR TITLE
intentionally record video without audio and bypass permission checks

### DIFF
--- a/library/src/main/java/com/afollestad/materialcamera/MaterialCamera.java
+++ b/library/src/main/java/com/afollestad/materialcamera/MaterialCamera.java
@@ -65,6 +65,7 @@ public class MaterialCamera {
     private boolean mContinueTimerInPlayback = true;
     private boolean mForceCamera1 = false;
     private boolean mStillShot;
+    private boolean mAudioDisabled = false;
     private long mAutoRecord = -1;
 
     private int mVideoEncodingBitRate = -1;
@@ -186,6 +187,11 @@ public class MaterialCamera {
 
     public MaterialCamera forceCamera1() {
         mForceCamera1 = true;
+        return this;
+    }
+
+    public MaterialCamera audioDisabled(boolean disabled) {
+        mAudioDisabled = disabled;
         return this;
     }
 
@@ -320,7 +326,8 @@ public class MaterialCamera {
                 .putExtra(CameraIntentKey.RESTART_TIMER_ON_RETRY, mRestartTimerOnRetry)
                 .putExtra(CameraIntentKey.CONTINUE_TIMER_IN_PLAYBACK, mContinueTimerInPlayback)
                 .putExtra(CameraIntentKey.STILL_SHOT, mStillShot)
-                .putExtra(CameraIntentKey.AUTO_RECORD, mAutoRecord);
+                .putExtra(CameraIntentKey.AUTO_RECORD, mAutoRecord)
+                .putExtra(CameraIntentKey.AUDIO_DISABLED, mAudioDisabled);
 
         if (mVideoEncodingBitRate > 0)
             intent.putExtra(CameraIntentKey.VIDEO_BIT_RATE, mVideoEncodingBitRate);

--- a/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureActivity.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureActivity.java
@@ -152,7 +152,7 @@ public abstract class BaseCaptureActivity extends AppCompatActivity implements B
         }
         final boolean cameraGranted = ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED;
         final boolean audioGranted = ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED;
-        final boolean audioNeeded = !useStillshot();
+        final boolean audioNeeded = !useStillshot() && !audioDisabled();
 
         String[] perms = null;
         if (cameraGranted) {
@@ -573,5 +573,10 @@ public abstract class BaseCaptureActivity extends AppCompatActivity implements B
     @Override
     public long autoRecordDelay() {
         return getIntent().getLongExtra(CameraIntentKey.AUTO_RECORD, -1);
+    }
+
+    @Override
+    public boolean audioDisabled() {
+        return getIntent().getBooleanExtra(CameraIntentKey.AUDIO_DISABLED, false);
     }
 }

--- a/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureInterface.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureInterface.java
@@ -134,4 +134,6 @@ public interface BaseCaptureInterface {
     boolean shouldHideFlash();
 
     long autoRecordDelay();
+
+    boolean audioDisabled();
 }

--- a/library/src/main/java/com/afollestad/materialcamera/internal/Camera2Fragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/Camera2Fragment.java
@@ -792,13 +792,17 @@ public class Camera2Fragment extends BaseCameraFragment implements View.OnClickL
             mMediaRecorder = new MediaRecorder();
 
         boolean canUseAudio = true;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-            canUseAudio = ContextCompat.checkSelfPermission(activity, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED;
+        if (!mInterface.audioDisabled()) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+                canUseAudio = ContextCompat.checkSelfPermission(activity, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED;
 
-        if (canUseAudio) {
-            mMediaRecorder.setAudioSource(MediaRecorder.AudioSource.DEFAULT);
+            if (canUseAudio) {
+                mMediaRecorder.setAudioSource(MediaRecorder.AudioSource.DEFAULT);
+            } else {
+                Toast.makeText(getActivity(), R.string.mcam_no_audio_access, Toast.LENGTH_LONG).show();
+            }
         } else {
-            Toast.makeText(getActivity(), R.string.mcam_no_audio_access, Toast.LENGTH_LONG).show();
+            canUseAudio = false;
         }
         mMediaRecorder.setVideoSource(MediaRecorder.VideoSource.SURFACE);
 

--- a/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
@@ -327,13 +327,17 @@ public class CameraFragment extends BaseCameraFragment implements View.OnClickLi
             mMediaRecorder.setCamera(mCamera);
 
             boolean canUseAudio = true;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-                canUseAudio = ContextCompat.checkSelfPermission(activity, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED;
+            if (!mInterface.audioDisabled()) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+                    canUseAudio = ContextCompat.checkSelfPermission(activity, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED;
 
-            if (canUseAudio) {
-                mMediaRecorder.setAudioSource(MediaRecorder.AudioSource.DEFAULT);
+                if (canUseAudio) {
+                    mMediaRecorder.setAudioSource(MediaRecorder.AudioSource.DEFAULT);
+                } else {
+                    Toast.makeText(getActivity(), R.string.mcam_no_audio_access, Toast.LENGTH_LONG).show();
+                }
             } else {
-                Toast.makeText(getActivity(), R.string.mcam_no_audio_access, Toast.LENGTH_LONG).show();
+                canUseAudio = false;
             }
             mMediaRecorder.setVideoSource(MediaRecorder.VideoSource.DEFAULT);
 

--- a/library/src/main/java/com/afollestad/materialcamera/internal/CameraIntentKey.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/CameraIntentKey.java
@@ -21,6 +21,7 @@ public class CameraIntentKey {
     public static final String CONTINUE_TIMER_IN_PLAYBACK = "continue_timer_in_playback";
     public static final String VIDEO_BIT_RATE = "video_bit_rate";
     public static final String AUDIO_ENCODING_BIT_RATE = "audio_encoding_bit_rate";
+    public static final String AUDIO_DISABLED = "audio_disabled";
     public static final String VIDEO_FRAME_RATE = "video_frame_rate";
     public static final String VIDEO_PREFERRED_HEIGHT = "video_preferred_height";
     public static final String VIDEO_PREFERRED_ASPECT = "video_preferred_aspect";


### PR DESCRIPTION
I have a use case where it is necessary to record a video clip without audio streams and wanted to bypass the permissions request and warning messages if audio permissions were not granted already. 