### PR TITLE
Various Bug Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.0'
     }
 }
 

--- a/library/src/main/java/com/afollestad/materialcamera/internal/BaseCameraFragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/BaseCameraFragment.java
@@ -162,7 +162,7 @@ abstract class BaseCameraFragment extends Fragment implements CameraUriInterface
 
     protected void onFlashModesLoaded() {
         if (getCurrentCameraPosition() != BaseCaptureActivity.CAMERA_POSITION_FRONT) {
-            invalidateFlash();
+            invalidateFlash(false);
         }
     }
 
@@ -412,12 +412,12 @@ abstract class BaseCameraFragment extends Fragment implements CameraUriInterface
         } else if (id == R.id.stillshot) {
             takeStillshot();
         } else if (id == R.id.flash) {
-            invalidateFlash();
+            invalidateFlash(true);
         }
     }
 
-    private void invalidateFlash() {
-        mInterface.toggleFlashMode();
+    private void invalidateFlash(boolean toggle) {
+        if (toggle) mInterface.toggleFlashMode();
         setupFlashMode();
         onPreferencesUpdated();
     }

--- a/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureActivity.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureActivity.java
@@ -331,7 +331,7 @@ public abstract class BaseCaptureActivity extends AppCompatActivity implements B
                 finish();
                 return;
             }
-            useVideo(outputUri);
+            useMedia(outputUri);
         } else {
             if (!hasLengthLimit() || !continueTimerInPlayback()) {
                 // No countdown or countdown should not continue through playback, reset timer to 0
@@ -348,7 +348,7 @@ public abstract class BaseCaptureActivity extends AppCompatActivity implements B
     @Override
     public void onShowStillshot(String outputUri) {
         if (shouldAutoSubmit()) {
-            useVideo(outputUri);
+            useMedia(outputUri);
         } else {
             Fragment frag = StillshotPreviewFragment.newInstance(outputUri, allowRetry(),
                     getIntent().getIntExtra(CameraIntentKey.PRIMARY_COLOR, 0));
@@ -401,7 +401,7 @@ public abstract class BaseCaptureActivity extends AppCompatActivity implements B
     }
 
     @Override
-    public final void useVideo(String uri) {
+    public final void useMedia(String uri) {
         if (uri != null) {
             setResult(Activity.RESULT_OK, getIntent()
                     .putExtra(MaterialCamera.STATUS_EXTRA, MaterialCamera.STATUS_RECORDED)

--- a/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureActivity.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureActivity.java
@@ -347,11 +347,15 @@ public abstract class BaseCaptureActivity extends AppCompatActivity implements B
 
     @Override
     public void onShowStillshot(String outputUri) {
-        Fragment frag = StillshotPreviewFragment.newInstance(outputUri, allowRetry(),
-                getIntent().getIntExtra(CameraIntentKey.PRIMARY_COLOR, 0));
-        getFragmentManager().beginTransaction()
-                .replace(R.id.container, frag)
-                .commit();
+        if (shouldAutoSubmit()) {
+            useVideo(outputUri);
+        } else {
+            Fragment frag = StillshotPreviewFragment.newInstance(outputUri, allowRetry(),
+                    getIntent().getIntExtra(CameraIntentKey.PRIMARY_COLOR, 0));
+            getFragmentManager().beginTransaction()
+                    .replace(R.id.container, frag)
+                    .commit();
+        }
     }
 
     @Override

--- a/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureInterface.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureInterface.java
@@ -48,7 +48,7 @@ public interface BaseCaptureInterface {
 
     Object getBackCamera();
 
-    void useVideo(String uri);
+    void useMedia(String uri);
 
     boolean shouldAutoSubmit();
 

--- a/library/src/main/java/com/afollestad/materialcamera/internal/Camera2Fragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/Camera2Fragment.java
@@ -467,30 +467,39 @@ public class Camera2Fragment extends BaseCameraFragment implements View.OnClickL
                 }
             }
 
-            if (mInterface.getCurrentCameraPosition() == CAMERA_POSITION_UNKNOWN) {
-                if (getArguments().getBoolean(CameraIntentKey.DEFAULT_TO_FRONT_FACING, false)) {
-                    // Check front facing first
-                    if (mInterface.getFrontCamera() != null) {
-                        setImageRes(mButtonFacing, mInterface.iconRearCamera());
-                        mInterface.setCameraPosition(CAMERA_POSITION_FRONT);
-                    } else {
-                        setImageRes(mButtonFacing, mInterface.iconFrontCamera());
-                        if (mInterface.getBackCamera() != null)
-                            mInterface.setCameraPosition(CAMERA_POSITION_BACK);
-                        else mInterface.setCameraPosition(CAMERA_POSITION_UNKNOWN);
-                    }
-                } else {
-                    // Check back facing first
-                    if (mInterface.getBackCamera() != null) {
-                        setImageRes(mButtonFacing, mInterface.iconFrontCamera());
-                        mInterface.setCameraPosition(CAMERA_POSITION_BACK);
-                    } else {
-                        setImageRes(mButtonFacing, mInterface.iconRearCamera());
-                        if (mInterface.getFrontCamera() != null)
+            switch (mInterface.getCurrentCameraPosition()) {
+                case CAMERA_POSITION_FRONT:
+                    setImageRes(mButtonFacing, mInterface.iconFrontCamera());
+                    break;
+                case CAMERA_POSITION_BACK:
+                    setImageRes(mButtonFacing, mInterface.iconRearCamera());
+                    break;
+                case CAMERA_POSITION_UNKNOWN:
+                default:
+                    if (getArguments().getBoolean(CameraIntentKey.DEFAULT_TO_FRONT_FACING, false)) {
+                        // Check front facing first
+                        if (mInterface.getFrontCamera() != null) {
+                            setImageRes(mButtonFacing, mInterface.iconFrontCamera());
                             mInterface.setCameraPosition(CAMERA_POSITION_FRONT);
-                        else mInterface.setCameraPosition(CAMERA_POSITION_UNKNOWN);
+                        } else {
+                            setImageRes(mButtonFacing, mInterface.iconRearCamera());
+                            if (mInterface.getBackCamera() != null)
+                                mInterface.setCameraPosition(CAMERA_POSITION_BACK);
+                            else mInterface.setCameraPosition(CAMERA_POSITION_UNKNOWN);
+                        }
+                    } else {
+                        // Check back facing first
+                        if (mInterface.getBackCamera() != null) {
+                            setImageRes(mButtonFacing, mInterface.iconRearCamera());
+                            mInterface.setCameraPosition(CAMERA_POSITION_BACK);
+                        } else {
+                            setImageRes(mButtonFacing, mInterface.iconFrontCamera());
+                            if (mInterface.getFrontCamera() != null)
+                                mInterface.setCameraPosition(CAMERA_POSITION_FRONT);
+                            else mInterface.setCameraPosition(CAMERA_POSITION_UNKNOWN);
+                        }
                     }
-                }
+                    break;
             }
 
             // Choose the sizes for camera preview and video recording

--- a/library/src/main/java/com/afollestad/materialcamera/internal/Camera2Fragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/Camera2Fragment.java
@@ -469,20 +469,20 @@ public class Camera2Fragment extends BaseCameraFragment implements View.OnClickL
 
             switch (mInterface.getCurrentCameraPosition()) {
                 case CAMERA_POSITION_FRONT:
-                    setImageRes(mButtonFacing, mInterface.iconFrontCamera());
+                    setImageRes(mButtonFacing, mInterface.iconRearCamera());
                     break;
                 case CAMERA_POSITION_BACK:
-                    setImageRes(mButtonFacing, mInterface.iconRearCamera());
+                    setImageRes(mButtonFacing, mInterface.iconFrontCamera());
                     break;
                 case CAMERA_POSITION_UNKNOWN:
                 default:
                     if (getArguments().getBoolean(CameraIntentKey.DEFAULT_TO_FRONT_FACING, false)) {
                         // Check front facing first
                         if (mInterface.getFrontCamera() != null) {
-                            setImageRes(mButtonFacing, mInterface.iconFrontCamera());
+                            setImageRes(mButtonFacing, mInterface.iconRearCamera());
                             mInterface.setCameraPosition(CAMERA_POSITION_FRONT);
                         } else {
-                            setImageRes(mButtonFacing, mInterface.iconRearCamera());
+                            setImageRes(mButtonFacing, mInterface.iconFrontCamera());
                             if (mInterface.getBackCamera() != null)
                                 mInterface.setCameraPosition(CAMERA_POSITION_BACK);
                             else mInterface.setCameraPosition(CAMERA_POSITION_UNKNOWN);
@@ -490,10 +490,10 @@ public class Camera2Fragment extends BaseCameraFragment implements View.OnClickL
                     } else {
                         // Check back facing first
                         if (mInterface.getBackCamera() != null) {
-                            setImageRes(mButtonFacing, mInterface.iconRearCamera());
+                            setImageRes(mButtonFacing, mInterface.iconFrontCamera());
                             mInterface.setCameraPosition(CAMERA_POSITION_BACK);
                         } else {
-                            setImageRes(mButtonFacing, mInterface.iconFrontCamera());
+                            setImageRes(mButtonFacing, mInterface.iconRearCamera());
                             if (mInterface.getFrontCamera() != null)
                                 mInterface.setCameraPosition(CAMERA_POSITION_FRONT);
                             else mInterface.setCameraPosition(CAMERA_POSITION_UNKNOWN);

--- a/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
@@ -177,20 +177,20 @@ public class CameraFragment extends BaseCameraFragment implements View.OnClickLi
 
             switch (getCurrentCameraPosition()) {
                 case CAMERA_POSITION_FRONT:
-                    setImageRes(mButtonFacing, mInterface.iconFrontCamera());
+                    setImageRes(mButtonFacing, mInterface.iconRearCamera());
                     break;
                 case CAMERA_POSITION_BACK:
-                    setImageRes(mButtonFacing, mInterface.iconRearCamera());
+                    setImageRes(mButtonFacing, mInterface.iconFrontCamera());
                     break;
                 case CAMERA_POSITION_UNKNOWN:
                 default:
                     if (getArguments().getBoolean(CameraIntentKey.DEFAULT_TO_FRONT_FACING, false)) {
                         // Check front facing first
                         if (mInterface.getFrontCamera() != null && (Integer) mInterface.getFrontCamera() != -1) {
-                            setImageRes(mButtonFacing, mInterface.iconFrontCamera());
+                            setImageRes(mButtonFacing, mInterface.iconRearCamera());
                             mInterface.setCameraPosition(CAMERA_POSITION_FRONT);
                         } else {
-                            setImageRes(mButtonFacing, mInterface.iconRearCamera());
+                            setImageRes(mButtonFacing, mInterface.iconFrontCamera());
                             if (mInterface.getBackCamera() != null && (Integer) mInterface.getBackCamera() != -1)
                                 mInterface.setCameraPosition(CAMERA_POSITION_BACK);
                             else mInterface.setCameraPosition(CAMERA_POSITION_UNKNOWN);
@@ -198,10 +198,10 @@ public class CameraFragment extends BaseCameraFragment implements View.OnClickLi
                     } else {
                         // Check back facing first
                         if (mInterface.getBackCamera() != null && (Integer) mInterface.getBackCamera() != -1) {
-                            setImageRes(mButtonFacing, mInterface.iconRearCamera());
+                            setImageRes(mButtonFacing, mInterface.iconFrontCamera());
                             mInterface.setCameraPosition(CAMERA_POSITION_BACK);
                         } else {
-                            setImageRes(mButtonFacing, mInterface.iconFrontCamera());
+                            setImageRes(mButtonFacing, mInterface.iconRearCamera());
                             if (mInterface.getFrontCamera() != null && (Integer) mInterface.getFrontCamera() != -1)
                                 mInterface.setCameraPosition(CAMERA_POSITION_FRONT);
                             else mInterface.setCameraPosition(CAMERA_POSITION_UNKNOWN);

--- a/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
@@ -232,16 +232,18 @@ public class CameraFragment extends BaseCameraFragment implements View.OnClickLi
                     parameters.setRecordingHint(true);
             }
 
-
-            mFlashModes = CameraUtil.getSupportedFlashModes(this.getActivity(), parameters);
-            mInterface.setFlashModes(mFlashModes);
-            onFlashModesLoaded();
-
             Camera.Size mStillShotSize = getHighestSupportedStillShotSize(parameters.getSupportedPictureSizes());
             parameters.setPictureSize(mStillShotSize.width, mStillShotSize.height);
 
             setCameraDisplayOrientation(parameters);
             mCamera.setParameters(parameters);
+
+            // NOTE: onFlashModesLoaded should not be called while modifying camera parameters as
+            //       the flash parameters set in setupFlashMode will then be overwritten
+            mFlashModes = CameraUtil.getSupportedFlashModes(this.getActivity(), parameters);
+            mInterface.setFlashModes(mFlashModes);
+            onFlashModesLoaded();
+
             createPreview();
             mMediaRecorder = new MediaRecorder();
 

--- a/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
@@ -174,30 +174,40 @@ public class CameraFragment extends BaseCameraFragment implements View.OnClickLi
                     }
                 }
             }
-            if (getCurrentCameraPosition() == CAMERA_POSITION_UNKNOWN) {
-                if (getArguments().getBoolean(CameraIntentKey.DEFAULT_TO_FRONT_FACING, false)) {
-                    // Check front facing first
-                    if (mInterface.getFrontCamera() != null && (Integer) mInterface.getFrontCamera() != -1) {
-                        setImageRes(mButtonFacing, mInterface.iconRearCamera());
-                        mInterface.setCameraPosition(CAMERA_POSITION_FRONT);
-                    } else {
-                        setImageRes(mButtonFacing, mInterface.iconFrontCamera());
-                        if (mInterface.getBackCamera() != null && (Integer) mInterface.getBackCamera() != -1)
-                            mInterface.setCameraPosition(CAMERA_POSITION_BACK);
-                        else mInterface.setCameraPosition(CAMERA_POSITION_UNKNOWN);
-                    }
-                } else {
-                    // Check back facing first
-                    if (mInterface.getBackCamera() != null && (Integer) mInterface.getBackCamera() != -1) {
-                        setImageRes(mButtonFacing, mInterface.iconFrontCamera());
-                        mInterface.setCameraPosition(CAMERA_POSITION_BACK);
-                    } else {
-                        setImageRes(mButtonFacing, mInterface.iconRearCamera());
-                        if (mInterface.getFrontCamera() != null && (Integer) mInterface.getFrontCamera() != -1)
+
+            switch (getCurrentCameraPosition()) {
+                case CAMERA_POSITION_FRONT:
+                    setImageRes(mButtonFacing, mInterface.iconFrontCamera());
+                    break;
+                case CAMERA_POSITION_BACK:
+                    setImageRes(mButtonFacing, mInterface.iconRearCamera());
+                    break;
+                case CAMERA_POSITION_UNKNOWN:
+                default:
+                    if (getArguments().getBoolean(CameraIntentKey.DEFAULT_TO_FRONT_FACING, false)) {
+                        // Check front facing first
+                        if (mInterface.getFrontCamera() != null && (Integer) mInterface.getFrontCamera() != -1) {
+                            setImageRes(mButtonFacing, mInterface.iconFrontCamera());
                             mInterface.setCameraPosition(CAMERA_POSITION_FRONT);
-                        else mInterface.setCameraPosition(CAMERA_POSITION_UNKNOWN);
+                        } else {
+                            setImageRes(mButtonFacing, mInterface.iconRearCamera());
+                            if (mInterface.getBackCamera() != null && (Integer) mInterface.getBackCamera() != -1)
+                                mInterface.setCameraPosition(CAMERA_POSITION_BACK);
+                            else mInterface.setCameraPosition(CAMERA_POSITION_UNKNOWN);
+                        }
+                    } else {
+                        // Check back facing first
+                        if (mInterface.getBackCamera() != null && (Integer) mInterface.getBackCamera() != -1) {
+                            setImageRes(mButtonFacing, mInterface.iconRearCamera());
+                            mInterface.setCameraPosition(CAMERA_POSITION_BACK);
+                        } else {
+                            setImageRes(mButtonFacing, mInterface.iconFrontCamera());
+                            if (mInterface.getFrontCamera() != null && (Integer) mInterface.getFrontCamera() != -1)
+                                mInterface.setCameraPosition(CAMERA_POSITION_FRONT);
+                            else mInterface.setCameraPosition(CAMERA_POSITION_UNKNOWN);
+                        }
                     }
-                }
+                    break;
             }
 
             if (mWindowSize == null)

--- a/library/src/main/java/com/afollestad/materialcamera/internal/PlaybackVideoFragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/PlaybackVideoFragment.java
@@ -138,7 +138,7 @@ public class PlaybackVideoFragment extends Fragment implements CameraUriInterfac
             mPlayer = null;
         }
         if (mInterface != null)
-            mInterface.useVideo(mOutputUri);
+            mInterface.useMedia(mOutputUri);
     }
 
     @Override

--- a/library/src/main/java/com/afollestad/materialcamera/internal/StillshotPreviewFragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/StillshotPreviewFragment.java
@@ -97,6 +97,6 @@ public class StillshotPreviewFragment extends BaseGalleryFragment {
         if (v.getId() == R.id.retry)
             mInterface.onRetry(mOutputUri);
         else if (v.getId() == R.id.confirm)
-            mInterface.useVideo(mOutputUri);
+            mInterface.useMedia(mOutputUri);
     }
 }

--- a/library/src/main/java/com/afollestad/materialcamera/util/ImageUtil.java
+++ b/library/src/main/java/com/afollestad/materialcamera/util/ImageUtil.java
@@ -14,6 +14,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
+import static com.afollestad.materialcamera.util.Degrees.DEGREES_270;
+import static com.afollestad.materialcamera.util.Degrees.DEGREES_90;
+
 /**
  * Created by tomiurankar on 06/03/16.
  */
@@ -68,7 +71,7 @@ public class ImageUtil {
         final BitmapFactory.Options opts = new BitmapFactory.Options();
         opts.inJustDecodeBounds = true;
         BitmapFactory.decodeFile(inputFile, opts);
-        opts.inSampleSize = calculateInSampleSize(opts, reqWidth, reqHeight);
+        opts.inSampleSize = calculateInSampleSize(opts, reqWidth, reqHeight, rotationInDegrees);
         opts.inJustDecodeBounds = false;
 
         final Bitmap origBitmap = BitmapFactory.decodeFile(inputFile, opts);
@@ -78,17 +81,25 @@ public class ImageUtil {
 
         Matrix matrix = new Matrix();
         matrix.preRotate(rotationInDegrees);
-        // we need not check if the rotation is not needed, since the below function will then return the same bitmap. Thus no memory loss occurs.
 
         return Bitmap.createBitmap(origBitmap, 0, 0, origBitmap.getWidth(), origBitmap.getHeight(), matrix, true);
     }
 
-    private static int calculateInSampleSize(BitmapFactory.Options options, int reqWidth, int reqHeight) {
+    private static int calculateInSampleSize(BitmapFactory.Options options, int reqWidth, int reqHeight, int rotationInDegrees) {
 
         // Raw height and width of image
-        final int height = options.outHeight;
-        final int width = options.outWidth;
+        final int height;
+        final int width;
         int inSampleSize = 1;
+
+        // Check rotation
+        if(rotationInDegrees == DEGREES_90 || rotationInDegrees == DEGREES_270){
+            width = options.outHeight;
+            height = options.outWidth;
+        } else {
+            height = options.outHeight;
+            width = options.outWidth;
+        }
 
         if (height > reqHeight || width > reqWidth) {
             // Calculate ratios of height and width to requested height and width

--- a/library/src/main/java/com/afollestad/materialcamera/util/ImageUtil.java
+++ b/library/src/main/java/com/afollestad/materialcamera/util/ImageUtil.java
@@ -81,6 +81,7 @@ public class ImageUtil {
 
         Matrix matrix = new Matrix();
         matrix.preRotate(rotationInDegrees);
+        // we need not check if the rotation is not needed, since the below function will then return the same bitmap. Thus no memory loss occurs.
 
         return Bitmap.createBitmap(origBitmap, 0, 0, origBitmap.getWidth(), origBitmap.getHeight(), matrix, true);
     }

--- a/library/src/main/java/com/afollestad/materialcamera/util/ImageUtil.java
+++ b/library/src/main/java/com/afollestad/materialcamera/util/ImageUtil.java
@@ -92,7 +92,7 @@ public class ImageUtil {
         final int width;
         int inSampleSize = 1;
 
-        // Check rotation
+        // Check for rotation
         if(rotationInDegrees == DEGREES_90 || rotationInDegrees == DEGREES_270){
             width = options.outHeight;
             height = options.outWidth;


### PR DESCRIPTION
## Changelog

We've submitted a number of bug fixes that resolve all of the issues we were seeing with the stillshot branch. @tylerkrupicka and I tested these changes on a range of devices, and this patch should iron out some of the issues with icons, memory, and autosubmit.

#### Camera Facing Button Fix

The issue of the camera "facing" button not being drawn on retry was due to missing logic in the `openCamera()` function which caused the image resource to only be loaded when the camera "facing" mode was unknown (or toggled).

#### Fix autoSubmit() and allowRetry() on Stillshot

Previously, the auto submit function would have no effect when launching for stillshot. This functionality has been fixed to follow the same behavior as video.

#### Fix Out of Memory Errors

We were able to dramatically reduce the amount of memory used when displaying bitmaps by fixing the sample size calculation. This fix has since been added to master, however we've included some images from testing on the 6p.

![Before](http://i.imgur.com/TrwrUFE.png)
![After](http://i.imgur.com/dpGR0wt.png)

Additionally, we've added a patch to the sample size calculation that correctly adjusts the width and height when the image is rotated. Without this fix, our Samsung devices would use the incorrect width and height in the calculation and still use way too much memory.

#### Fix Flash Toggle Bug

We've fixed a bug that would cause the flash state to toggle when using the back button. We've also fixed a related bug which cause the flash icon to not match the selected mode for Camera 1 devices.

#### Test Galaxy S4

We were able to get our hands on a Galaxy S4 and were unable to reproduce any bugs with the preview size. We were able to verify the memory fix. 

### Testing

| Device              | Manufacturer | OS  | Video | Stillshot | Flash | Front & Back |
| ------------------- |:------------:|:---:|:-----:|:---------:|:-----:|:------------:|
| Nexus 6p            | Huewei       |6.0.1|   ✓  |      ✓    |   ✓   |       ✓     |
| Nexus 5             | LG           |6.0.1|   ✓  |      ✓    |   ✓   |       ✓     |
| Nexus 6             | Motorolla    |6.0.1|   ✓  |      ✓    |   ✓   |       ✓     |
| Droid Razr Maxx     | Motorolla    |4.4.2|   _X_* |      ✓    |   ✓   |       ✓     |
| Galaxy S6           | Samsung      |6.0.1|   ✓  |      ✓    |   ✓   |       ✓     |
| Galaxy S5           | Samsung      |6.0.1|   ✓  |      ✓    |   ✓   |       ✓     |
| Galaxy S4           | Samsung      |5.0.1|   ✓  |      ✓    |   ✓   |       ✓     |
| Galaxy S3 (SCH-I525)| Samsung      |4.4.2|   _X_* |      ✓    |   ✓   |       ✓     |

*These are existing issues in the main repo (`invalid drawable tag vector` while creating the `PlaybackVideoFragment`)

### Going Forward

We have plans to add torch flash mode to video and try to fix the upside down preview bug when time permits. We hope @afollestad can take a look and verify these changes before merging them in. Hope this helps!
