### PR TITLE
Added support for press and hold to record video like snapchat

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ new MaterialCamera(this)                               // Constructor takes an A
     .videoPreferredHeight(720)                         // Sets a preferred height for the recorded video output.
     .videoPreferredAspect(4f / 3f)                     // Sets a preferred aspect ratio for the recorded video output.
     .maxAllowedFileSize(1024 * 1024 * 5)               // Sets a max file size of 5MB, recording will stop if file reaches this limit. Keep in mind, the FAT file system has a file size limit of 4GB.
+    .holdToRecord(false)                               // If true, enabled press and hold to record video and stops recording when finger is released
     .iconRecord(R.drawable.mcam_action_capture)        // Sets a custom icon for the button used to start recording
     .iconStop(R.drawable.mcam_action_stop)             // Sets a custom icon for the button used to stop recording
     .iconFrontCamera(R.drawable.mcam_camera_front)     // Sets a custom icon for the button used to switch to the front camera

--- a/library/src/main/java/com/afollestad/materialcamera/MaterialCamera.java
+++ b/library/src/main/java/com/afollestad/materialcamera/MaterialCamera.java
@@ -67,6 +67,7 @@ public class MaterialCamera {
     private boolean mForceCamera1 = false;
     private boolean mStillShot;
     private boolean mAudioDisabled = false;
+    private boolean mHoldToRecord = false;
     private long mAutoRecord = -1;
 
     private int mVideoEncodingBitRate = -1;
@@ -198,6 +199,13 @@ public class MaterialCamera {
 
     public MaterialCamera audioDisabled(boolean disabled) {
         mAudioDisabled = disabled;
+        return this;
+    }
+
+    public MaterialCamera holdToRecord(boolean holdRecord) {
+        if (!mStillShot) {
+            mHoldToRecord = holdRecord;
+        }
         return this;
     }
 
@@ -350,6 +358,9 @@ public class MaterialCamera {
             intent.putExtra(CameraIntentKey.MAX_ALLOWED_FILE_SIZE, mMaxFileSize);
         if (mQualityProfile > -1)
             intent.putExtra(CameraIntentKey.QUALITY_PROFILE, mQualityProfile);
+        if (mHoldToRecord) {
+            intent.putExtra(CameraIntentKey.HOLD_TO_RECORD, mHoldToRecord);
+        }
 
         if (mIconRecord != 0)
             intent.putExtra(CameraIntentKey.ICON_RECORD, mIconRecord);

--- a/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureActivity.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureActivity.java
@@ -368,6 +368,11 @@ public abstract class BaseCaptureActivity extends AppCompatActivity implements B
         return getIntent().getBooleanExtra(CameraIntentKey.AUTO_SUBMIT, false);
     }
 
+    @Override
+    public final boolean holdToRecord() {
+        return getIntent().getBooleanExtra(CameraIntentKey.HOLD_TO_RECORD, false);
+    }
+
     private void deleteOutputFile(@Nullable String uri) {
         if (uri != null)
             //noinspection ResultOfMethodCallIgnored

--- a/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureInterface.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureInterface.java
@@ -62,6 +62,8 @@ public interface BaseCaptureInterface {
 
     boolean continueTimerInPlayback();
 
+    boolean holdToRecord();
+
     int videoEncodingBitRate(int defaultVal);
 
     int audioEncodingBitRate(int defaultVal);

--- a/library/src/main/java/com/afollestad/materialcamera/internal/CameraIntentKey.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/CameraIntentKey.java
@@ -28,6 +28,7 @@ public class CameraIntentKey {
     public static final String MAX_ALLOWED_FILE_SIZE = "max_allowed_file_size";
     public static final String QUALITY_PROFILE = "quality_profile";
     public static final String ALLOW_CHANGE_CAMERA = "allow_change_camera";
+    public static final String HOLD_TO_RECORD = "hold_to_record";
 
     public static final String ICON_RECORD = "icon_record";
     public static final String ICON_STOP = "icon_stop";


### PR DESCRIPTION
Added support for press and hold to record video like Snapchat. Press and hold to record video. Release your finger to stop recording. Added the flag `.holdToRecord(true)` to enable press and hold.